### PR TITLE
Require geopandas, require py3.7, reinstate a reconfigure()

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ data tables. This also contains a column called `match_rule`, which refers to th
 4. Make sure you have PostgreSQL on your machine, then run the command: `createdb hut23-425 "Solar PV database matching"` - this creates the empty database.
 5. Navigate to `db` and run the command `psql -f make-database.sql hut23-425` - this populates the database (see [doc/database](doc/database.md)), carries out some de-duplication of the datasets and performs the matching procedure (see [doc/matching](doc/matching.md)). Note: this may take several minutes.
 
+Note that the above commands require you to have admin rights on your PostgreSQL server. On standard Debian-based machines you could prepend the commands with `sudo -u postgres`, or you could assign privileges to your own user account.
+
 ## External collaborators guidance
 
 From April 2020 this repo is no longer under active development, however a fork of the project is being created by [Open Climate Fix](https://github.com/openclimatefix) if you wish to open issues and pull requests there.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ data tables. This also contains a column called `match_rule`, which refers to th
 ### Install requirements
 
 1. Install [PostgreSQL](https://www.postgresql.org/download/)
-2. Install Python 3 and `pip`
+2. Install Python 3 (version 3.7 or later) and `pip`
 3. Run `pip install -r requirements.txt`
 4. Install [Osmium](https://osmcode.org/osmium-tool/)
 

--- a/data/processed/pre-process-repd.py
+++ b/data/processed/pre-process-repd.py
@@ -15,6 +15,7 @@ def clean_repd_csv(csv_str):
         csv_str = re.sub(rgx_match, '"', csv_str)
     return csv_str
 
+sys.stdin.reconfigure(encoding='iso-8859-1')
 repd_df = pd.read_csv(sys.stdin, skiprows=1)
 
 # Check the file has the columns we expect and order them as we expect

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ matplotlib
 numpy
 pandas
 scipy
+geopandas


### PR DESCRIPTION
I haven't found a way to get pandas not to choke on unusual characters in the FIT data (0xa0 which is "NBSP" in ascii but invalid in UTF-8), if I stick to python3.6. Hence this bumps requirement to 3.7+.

I also added a missing geopandas dependency