### PR TITLE
Add "rule 2.5" to merge-rules

### DIFF
--- a/db/data-matching-rules/rule-25.sql
+++ b/db/data-matching-rules/rule-25.sql
@@ -1,0 +1,23 @@
+-- Match rule 2.5 (see doc/matching.md)
+\echo -n Performing match rule 2.5...
+
+insert into matches
+select '25', closest_pt.master_repd_id, osm.master_osm_id
+from osm_repd_id_mapping LEFT JOIN osm USING (osm_id) LEFT JOIN repd_operational USING (repd_id)
+ -- selecting matching repd IDs, and finding their distance:
+ CROSS JOIN LATERAL
+   (SELECT
+      repd.master_repd_id,
+      osm.location::geography <-> repd.location::geography as distance_meters
+      FROM repd
+      WHERE repd.repd_id=osm_repd_id_mapping.repd_id
+        -- Not matches already found:
+	AND not exists (
+	    select
+	    from matches
+	    where matches.master_repd_id = repd_operational.master_repd_id
+	    or matches.master_osm_id = osm.master_osm_id
+	  )
+-- Only the single nearest-neighbour:
+ORDER BY osm.location::geography <-> repd.location::geography
+    LIMIT 1) AS closest_pt;

--- a/db/data-matching-rules/rule-25a.sql
+++ b/db/data-matching-rules/rule-25a.sql
@@ -1,0 +1,23 @@
+-- Match rule 2.5a (see doc/matching.md)
+\echo -n Performing match rule 2.5a...
+
+insert into matches
+select '25a', closest_pt.master_repd_id, osm.master_osm_id
+from osm_repd_id_mapping LEFT JOIN osm USING (osm_id) LEFT JOIN repd_non_operational USING (repd_id)
+ -- selecting matching repd IDs, and finding their distance:
+ CROSS JOIN LATERAL
+   (SELECT
+      repd.master_repd_id,
+      osm.location::geography <-> repd.location::geography as distance_meters
+      FROM repd
+      WHERE repd.repd_id=osm_repd_id_mapping.repd_id
+        -- Not matches already found:
+	AND not exists (
+	    select
+	    from matches
+	    where matches.master_repd_id = repd_non_operational.master_repd_id
+	    or matches.master_osm_id = osm.master_osm_id
+	  )
+-- Only the single nearest-neighbour:
+ORDER BY osm.location::geography <-> repd.location::geography
+    LIMIT 1) AS closest_pt;

--- a/db/data-matching.sql
+++ b/db/data-matching.sql
@@ -3,7 +3,7 @@
 
 drop table if exists matches;
 create table matches (
-  match_rule     varchar(2),
+  match_rule     varchar(3),
   master_repd_id integer,
   master_osm_id  bigint,
   mv_id          integer,
@@ -16,6 +16,7 @@ select * into repd_operational from repd where dev_status = 'Operational';
 
 \include data-matching-rules/rule-1.sql
 \include data-matching-rules/rule-2.sql
+\include data-matching-rules/rule-25.sql
 \include data-matching-rules/rule-3.sql
 \include data-matching-rules/rule-4.sql
 \include data-matching-rules/rule-5.sql
@@ -26,6 +27,7 @@ select * into repd_non_operational from repd where dev_status != 'Operational';
 
 \include data-matching-rules/rule-1a.sql
 \include data-matching-rules/rule-2a.sql
+\include data-matching-rules/rule-25a.sql
 \include data-matching-rules/rule-3a.sql
 \include data-matching-rules/rule-4a.sql
 \include data-matching-rules/rule-5a.sql

--- a/doc/matching.md
+++ b/doc/matching.md
@@ -11,7 +11,7 @@ This note documents the matching of entities between the various datasets in the
 First, proximity match to get the nearest neighbouring REPD for every single OSM object,
 
 1. The master REPD id of the REPD id in OSM, where this is < 500m from the nearest neighbour REPD object to an OSM object
-2. The nearest neighbour in meters of OSM entries to REPD entries where the REPD ID is the same as that already present in OSM data. Accept those that are the same (regardless of distance). This should catch any that aren't covered by rule 0.
+2. The nearest neighbour in meters of OSM entries to REPD entries where the REPD ID is the same as that already present in OSM data. Accept those that are the same (regardless of distance). This should catch any that aren't covered by rule 0. (Implementation note: added rule 2.5 which comes after rule 2, implementing the same idea with a different proximity search. It re-runs the nearest neighbour search but only for matching REPD IDs rather than any REPD ID.)
 3. Nearest neighbour for remaining OSM/REPD where the OSM `objtype` is `way` or `relation` and the object is a "group master" (the `osm_id = master_osm_id` or `repd_id = master_repd_id`). Accept all matches that are below a distance threshold of 700 meters.
 4. Nearest REPD neighbour for OSM nodes, where REPD has "Scheme" in the title, with a distance threshold of 5KM.
 5. Repeat 4, with no distance threshold


### PR DESCRIPTION
Hi Ed - I'm submitting this PR to the Turing's copy of the code, to request a sense-check from you. (I've other changes which I'll send downstream to Open Climate Fix.)

I found some REPD-OSM pairs that were not matched, despite explicit tagging in OSM. I think the issue is that rule 2 reuses rule 1's nearest neighbour search which isn't restricted to matching REPDs.

This uses an alternate nearest-neighbour search: rule 2 sticks with the nearest-REPD-item only, whereas rule 2.5 finds the nearest REPD item that also matches the tagged REPD id in OSM. In my test this increases the number of UK matches by 73, and fixes some un-matchings.